### PR TITLE
There are no railways in street_polygons layer

### DIFF
--- a/shortbread-website/content/schema/1.0.md
+++ b/shortbread-website/content/schema/1.0.md
@@ -427,7 +427,6 @@ from road class, OSM `layer=*`, `bridge=*` and `tunnel=*` tags. More important r
 | Field Name | Type     | Default      | Description                                                                                                      |
 | ---------- | :------- | :----------- | :--------------------------------------------------------------------------------------------------------------- |
 | kind       | string   | always set   | Feature class, contains value of `highway=*` or `area:aeroway=*`                                                 |
-| rail       | boolean  | false        | true for railways, false otherwise                                                                               |
 | tunnel     | boolean  | false        | true for `tunnel=yes/building_passage` or `covered=yes`, `false` otherwise                                       |
 | bridge     | boolean  | false        | true for `bridge=yes/viaduct/boardwalk/cantilever/covered/low_water_crossing/movable/trestle`, `false` otherwise |
 | surface    | string   | empty string | value of `surface=*`                                                                                             |


### PR DESCRIPTION
The description doesn't allow any "kind" with a rail value (and there are no areas for railways in the same way as there are areas for pedestrian highways etc.) So this field is superfluous.