### PR TITLE
Change amenity=playground to leisure=playground

### DIFF
--- a/shortbread-website/content/schema/1.1.md
+++ b/shortbread-website/content/schema/1.1.md
@@ -732,7 +732,6 @@ The following key-value combinations are included in this layer:
 - {{< tag amenity nursing_home >}}
 - {{< tag amenity pharmacy >}}
 - {{< tag amenity place_of_worship >}}
-- {{< tag amenity playground >}}
 - {{< tag amenity police >}}
 - {{< tag amenity post_box >}}
 - {{< tag amenity post_office >}}
@@ -767,6 +766,7 @@ The following key-value combinations are included in this layer:
 - {{< tag leisure golf_course >}}
 - {{< tag leisure ice_rink >}}
 - {{< tag leisure pitch >}}
+- {{< tag leisure playground >}}
 - {{< tag leisure sports_centre >}}
 - {{< tag leisure stadium >}}
 - {{< tag leisure swimming_pool >}}


### PR DESCRIPTION
The former is a tagging mistake that should never have been added.

Fixes #70