### PR TITLE
Rewrite 1.1 boundary section for clarity

### DIFF
--- a/shortbread-website/content/schema/1.1.md
+++ b/shortbread-website/content/schema/1.1.md
@@ -190,11 +190,22 @@ Holds boundary lines of countries and states.
 
 #### Properties
 
-| Field name    | Type    | Description                                                                                                                                                      |
-| ------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `admin_level` | integer | highest administrative boundary this line belongs to                                                                                                             |
-| `maritime`    | boolean | Boundary line is located on sea, base on OSM {{< tag maritime >}} tag, or is the coastline (way tagged with {{< tag natural coastline >}})                       |
-| `disputed`    | boolean | Boundary line is tagged with {{< tag disputed yes >}} or member of a relation with {{< tag boundary disputed >}} and `admin_level` unset or between `2` and `4`. |
+| Field name    | Type    | Description                                         |
+| ------------- | :------ | :-------------------------------------------------- |
+| `admin_level` | integer | The most significant admin_level of a boundary line |
+| `maritime`    | boolean | If a boundary line is on the sea                    |
+| `disputed`    | boolean | If a boundary line is disputed                      |
+
+Boundary ways are children of parent relation(s) with {{< tag type boundary >}}, {{< tag boundary administrative >}}, and {{< tag admin_level 2 4 >}}. The `admin_level` property of the linestring comes from the lowest numerical admin_level value of the parent relations. E.g. if a way is a member of one administrative boundary relation with {{< tag admin_level 2 >}} and a second with {{< tag admin_level 4 >}} the linestring has the `admin_level` property set to the integer `2`.
+
+A boundary line is considered `maritime` if the way has a:
+- {{< tag maritime yes>}} tag or
+- {{< tag natural coastline >}} tag.
+
+A boundary line is disputed if the way has a:
+- {{< tag disputed yes >}} tag on itself,
+- parent relation with {{< tag type boundary >}} and {{< tag boundary disputed >}} and no {{< tag admin_level >}}, or
+- parent relation with {{< tag type boundary >}} and {{< tag boundary disputed >}} and {{< tag admin_level 2 4 >}}.
 
 #### Features
 


### PR DESCRIPTION
The existing text was difficult to parse with multiple subordinate clauses. This rewrites the text to use lists and be more readable.

This change attempts to keep the logic the same, except the ambiguous case of admin_level=3 disputed boundaries.

Fixes #43